### PR TITLE
[KUNTECH-3081] Add isRegexMatch method and allow multiple sequantially handleUserBlur and handleUserInput calls

### DIFF
--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -87,7 +87,7 @@ const FormWrapper = (WrappedComponent) => {
         },
       };
 
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         this.setState(fields, resolve);
       });
     };
@@ -108,10 +108,12 @@ const FormWrapper = (WrappedComponent) => {
           },
         };
 
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           this.setState(fields, resolve);
         });
       }
+
+      return null;
     };
 
     /**

--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -80,11 +80,15 @@ const FormWrapper = (WrappedComponent) => {
     handleUserInput = (event) => {
       const {name, value} = event.target;
 
-      this.setState({
+      const fields = {
         fields: {
           ...this.state.fields,
           ...this.updateField(value, name),
         },
+      };
+
+      return new Promise(resolve => {
+        this.setState(fields, resolve);
       });
     };
 
@@ -97,11 +101,15 @@ const FormWrapper = (WrappedComponent) => {
 
       // When the form is submit, setting state in blur stops event propagation
       if (event.relatedTarget && event.relatedTarget.type !== 'submit') {
-        this.setState({
+        const fields = {
           fields: {
             ...this.state.fields,
             ...this.updateField(value, name, true),
           },
+        };
+
+        return new Promise(resolve => {
+          this.setState(fields, resolve);
         });
       }
     };

--- a/packages/kununu-form-wrapper/package.json
+++ b/packages/kununu-form-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kununu/kununu-form-wrapper",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "kununu form wrapper HOC",
     "main": "dist",
     "author": "kununu",

--- a/packages/kununu-utils/kununu-helpers/formValidation/index.js
+++ b/packages/kununu-utils/kununu-helpers/formValidation/index.js
@@ -51,8 +51,9 @@ export function isEmail (value) {
  * @author Pedro Menezes
  * @param {string} value [of input field]
  */
-export function isRegexMatch (value, match) {
-  if (!match.test(value)) {
+export function isRegexMatch (value, rule) {
+  const pattern = new RegExp(rule);
+  if (!pattern.test(value)) {
     return NOT_VALID;
   }
 

--- a/packages/kununu-utils/kununu-helpers/formValidation/index.js
+++ b/packages/kununu-utils/kununu-helpers/formValidation/index.js
@@ -46,10 +46,24 @@ export function isEmail (value) {
   return undefined;
 }
 
+/**
+ * Validates if a value matches a given regex
+ * @author Pedro Menezes
+ * @param {string} value [of input field]
+ */
+export function isRegexMatch (value, match) {
+  if (!match.test(value)) {
+    return NOT_VALID;
+  }
+
+  return undefined;
+}
+
 export const validationTypes = {
   isEmpty: 'isEmpty',
   minLength: 'minLength',
   isEmail: 'isEmail',
+  isRegexMatch: 'isRegexMatch',
 };
 
 /**
@@ -71,6 +85,9 @@ export function validateField (value, validations) {
         break;
       case validationTypes.isEmail:
         if (isEmail(value) !== undefined) return validation.message;
+        break;
+      case validationTypes.isRegexMatch:
+        if (isRegexMatch(value, validation.regexRule) !== undefined) return validation.message;
         break;
       default:
         break;

--- a/packages/kununu-utils/kununu-helpers/formValidation/index.js
+++ b/packages/kununu-utils/kununu-helpers/formValidation/index.js
@@ -54,7 +54,7 @@ export function isEmail (value) {
 export function isRegexMatch (value, rule, allowEmpty) {
   const pattern = new RegExp(rule);
 
-  if(value.trim().length === 0 && allowEmpty) {
+  if (value.trim().length === 0 && allowEmpty) {
     return undefined;
   }
 

--- a/packages/kununu-utils/kununu-helpers/formValidation/index.js
+++ b/packages/kununu-utils/kununu-helpers/formValidation/index.js
@@ -51,8 +51,13 @@ export function isEmail (value) {
  * @author Pedro Menezes
  * @param {string} value [of input field]
  */
-export function isRegexMatch (value, rule) {
+export function isRegexMatch (value, rule, allowEmpty) {
   const pattern = new RegExp(rule);
+
+  if(value.trim().length === 0 && allowEmpty) {
+    return undefined;
+  }
+
   if (!pattern.test(value)) {
     return NOT_VALID;
   }
@@ -88,7 +93,7 @@ export function validateField (value, validations) {
         if (isEmail(value) !== undefined) return validation.message;
         break;
       case validationTypes.isRegexMatch:
-        if (isRegexMatch(value, validation.regexRule) !== undefined) return validation.message;
+        if (isRegexMatch(value, validation.regexRule, validation.allowEmpty) !== undefined) return validation.message;
         break;
       default:
         break;

--- a/packages/kununu-utils/kununu-helpers/formValidation/index.spec.js
+++ b/packages/kununu-utils/kununu-helpers/formValidation/index.spec.js
@@ -2,6 +2,7 @@ import {
     notEmpty,
     minLength10,
     isEmail,
+    isRegexMatch,
     validateField,
     validationTypes,
 } from './index';
@@ -21,6 +22,19 @@ describe('formValidation methods', () => {
 
   it('Returns error when mail is invalid', () => {
     expect(isEmail('not_email')).toEqual('NOT_VALID');
+  });
+
+  it('Returns error when regex match is invalid', () => {
+    const fieldValue = 'https://www.kununu.com/de/xing';
+    const regexRule = '((https?:\\/\\/)?((www|\\w\\w)\\.)?xing\\.com\\/)profile\\/[\\w]+';
+
+    expect(isRegexMatch(fieldValue, regexRule, true)).toEqual('NOT_VALID');
+  });
+
+  it('Returns error when regex match is empty and allowEmpty is false', () => {
+    const regexRule = '((https?:\\/\\/)?((www|\\w\\w)\\.)?xing\\.com\\/)profile\\/[\\w]+';
+
+    expect(isRegexMatch('', regexRule, false)).toEqual('NOT_VALID');
   });
 });
 
@@ -47,5 +61,25 @@ describe('validates fields', () => {
       message: 'error',
     }];
     expect(validateField('long text', validations)).toEqual('error');
+  });
+
+  it('Returns error message when isRegexMatch input is not valid', () => {
+    const validations = [{
+      type: validationTypes.isRegexMatch,
+      regexRule: '((https?:\\/\\/)?((www|\\w\\w)\\.)?xing\\.com\\/)profile\\/[\\w]+',
+      allowEmpty: true,
+      message: 'error',
+    }];
+    expect(validateField('not a xing company url', validations)).toEqual('error');
+  });
+
+  it('Returns false when isRegexMatch input is valid', () => {
+    const validations = [{
+      type: validationTypes.isRegexMatch,
+      regexRule: '((https?:\\/\\/)?((www|\\w\\w)\\.)?xing\\.com\\/)profile\\/[\\w]+',
+      allowEmpty: true,
+      message: 'error',
+    }];
+    expect(validateField('https://xing.com/profile/kununu', validations)).toEqual(false);
   });
 });

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {


### PR DESCRIPTION
https://jira.xing.hh/browse/KUNTECH-3081

These changes are part of https://github.com/kununu/kununu/pull/914

Changes on FormWrapper HOC were made to allow call  `handleUserInput` and `handleUserBlur` successively. like when you have to edit multiple fields:

```js
async changeFieldsValues = (field1, field2, field3) => {
  await handleUserInput(field1);
  await handleUserInput(field2);
  await handleUserInput(field3);
  await handleUserInput(field4);
});
```

This wasn't possible before this change, you would only see the change being made to `field4` or whatever the last one is. By wrapping it into a promise on FormWrapper, async calls to multiple fields now works properly.

----

As far from the change introduced to formValidation, `isRegexMatch` now allows regex validation in a field against a given regex rule. 3rd parameter (`allowEmpty`) is mandatory because when true, a field can be also empty.