### PR TITLE
[KUNTECH-3615] Add support for cookies with object as value

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@kununu/kununu-theme-v2": "2.0.2",
-    "cookie": "0.3.1"
+    "@kununu/kununu-theme-v2": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@kununu/kununu-theme-v2": "2.0.2"
+    "@kununu/kununu-theme-v2": "2.0.2",
+    "cookie": "0.3.1"
   }
 }

--- a/packages/kununu-utils/kununu-helpers/cookies/cookies.spec.js
+++ b/packages/kununu-utils/kununu-helpers/cookies/cookies.spec.js
@@ -26,4 +26,12 @@ describe('cookies', () => {
 
     expect(cookies.get(cookieName)).toEqual(expectedParsedObject);
   });
+
+  it('can sucessfully save a cookie when its given value is an unparsed object', () => {
+    const cookieName = 'kununu_cookie_name';
+    const cookieValue = {valueA: 1, valueB: 2};
+    cookies.set(cookieName, cookieValue, {});
+
+    expect(cookies.get(cookieName)).toEqual(cookieValue);
+  });
 });

--- a/packages/kununu-utils/kununu-helpers/cookies/cookies.spec.js
+++ b/packages/kununu-utils/kununu-helpers/cookies/cookies.spec.js
@@ -18,15 +18,6 @@ describe('cookies', () => {
     expect(cookies.get('kununu_country')).toEqual('de');
   });
 
-  it('can parse json cookie', () => {
-    const cookieName = 'kununu_user_info';
-    const cookieValue = '%7B%22username%22%3A%22u38894%22%2C%22email%22%3A%22u38894%40kununu.dev%22%7D';
-    const expectedParsedObject = {username: 'u38894', email: 'u38894@kununu.dev'};
-    cookies.set(cookieName, cookieValue);
-
-    expect(cookies.get(cookieName)).toEqual(expectedParsedObject);
-  });
-
   it('can sucessfully save a cookie when its given value is an unparsed object', () => {
     const cookieName = 'kununu_cookie_name';
     const cookieValue = {valueA: 1, valueB: 2};

--- a/packages/kununu-utils/kununu-helpers/cookies/index.js
+++ b/packages/kununu-utils/kununu-helpers/cookies/index.js
@@ -1,4 +1,4 @@
-import cookie from 'cookie';
+import {serialize} from 'cookie';
 
 const cookies = {
   get: name => document.cookie.split('; ').reduce((r, v) => {
@@ -17,7 +17,7 @@ const cookies = {
       Object.keys(options).map(key => `${key}=${options[key]}`).join('; ') :
       null;
 
-    document.cookie = cookie.serialize(name, value, parsedOptions);
+    document.cookie = serialize(name, value, parsedOptions);
   },
 };
 

--- a/packages/kununu-utils/kununu-helpers/cookies/index.js
+++ b/packages/kununu-utils/kununu-helpers/cookies/index.js
@@ -10,7 +10,7 @@ const cookies = {
   set: (name, value, options) => {
     // allow you to work with cookies as objects.
     if (typeof value === 'object') {
-      value = JSON.stringify(value);
+      value = JSON.stringify(value); // eslint-disable-line no-param-reassign
     }
 
     const parsedOptions = typeof options === 'object' ?

--- a/packages/kununu-utils/kununu-helpers/cookies/index.js
+++ b/packages/kununu-utils/kununu-helpers/cookies/index.js
@@ -1,3 +1,5 @@
+import cookie from 'cookie';
+
 const cookies = {
   get: name => document.cookie.split('; ').reduce((r, v) => {
     const parts = v.split('=');
@@ -6,15 +8,16 @@ const cookies = {
     return shouldBeParsed ? JSON.parse(cookie) : cookie;
   }, ''),
   set: (name, value, options) => {
+    // allow you to work with cookies as objects.
+    if (typeof value === 'object') {
+      value = JSON.stringify(value);
+    }
+
     const parsedOptions = typeof options === 'object' ?
       Object.keys(options).map(key => `${key}=${options[key]}`).join('; ') :
       null;
 
-    const cookie = parsedOptions === null ?
-      `${name}=${value}; ` :
-      `${name}=${value}; ${parsedOptions}`;
-
-    document.cookie = cookie;
+    document.cookie = cookie.serialize(name, value, parsedOptions);
   },
 };
 

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -38,7 +38,5 @@
   },
   "author": "kununu",
   "license": "ISC",
-  "dependencies": {
-    "cookie": "0.3.1"
-  }
+  "dependencies": {}
 }

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {
@@ -26,7 +26,8 @@
     "react": "16.4.1",
     "react-scroll": "1.7.9",
     "winston": "3.0.0",
-    "jwt-decode": "2.2.0"
+    "jwt-decode": "2.2.0",
+    "cookie": "0.3.1"
   },
   "scripts": {
     "prepublish": "npm run build",
@@ -37,5 +38,7 @@
   },
   "author": "kununu",
   "license": "ISC",
-  "dependencies": {}
+  "dependencies": {
+    "cookie": "0.3.1"
+  }
 }

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -18,7 +18,8 @@
     "react-scroll": "1.7.9",
     "rimraf": "2.6.2",
     "supertest": "3.1.0",
-    "winston": "3.0.0"
+    "winston": "3.0.0",
+    "cookie": "0.3.1"
   },
   "peerDependencies": {
     "http-status-codes": "1.1.6",


### PR DESCRIPTION
Currently, it's only working properly when cookie values are strings. Objects won't even save or throw any error.

Changes were made to allow objects as cookie values and `cookie` lib make proper serializing of a cookie before save it - only `JSON.stringify()` wasn't enough to make it work.