### PR TITLE
Update formwrapper

### DIFF
--- a/packages/kununu-form-wrapper/__snapshots__/index.spec.jsx.snap
+++ b/packages/kununu-form-wrapper/__snapshots__/index.spec.jsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Returns current domain from a request object renders async initial fields without crashing 1`] = `
+<MockComponent
+  fields={Object {}}
+  formIsEmpty={[Function]}
+  getFormFieldProps={[Function]}
+  getInitialFields={[Function]}
+  handleCustomError={[Function]}
+  handleSubmit={[Function]}
+  handleUserBlur={[Function]}
+  handleUserInput={[Function]}
+  resetFormFields={[Function]}
+  touchForm={[Function]}
+  updateLocalStorageFromState={[Function]}
+  updateStateFromLocalStorage={[Function]}
+/>
+`;
+
 exports[`Returns current domain from a request object renders without crashing 1`] = `
 <MockComponent
   fields={
@@ -17,8 +34,10 @@ exports[`Returns current domain from a request object renders without crashing 1
       },
     }
   }
+  formIsEmpty={[Function]}
   getFormFieldProps={[Function]}
   getInitialFields={[Function]}
+  handleCustomError={[Function]}
   handleSubmit={[Function]}
   handleUserBlur={[Function]}
   handleUserInput={[Function]}

--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -4,13 +4,6 @@ import {validateField} from '@kununu/kununu-utils/dist/kununu-helpers/formValida
 
 const FormWrapper = (WrappedComponent) => {
   class HOC extends React.Component {
-    constructor (props) {
-      super(props);
-      this.state = {
-        fields: this.props.getInitialFields(),
-      };
-    }
-
     /**
      * If the initial fields are loaded
      * async then they will be empty upon initial load.
@@ -24,6 +17,14 @@ const FormWrapper = (WrappedComponent) => {
 
       return {
         fields: nextProps.getInitialFields(),
+      };
+    }
+
+
+    constructor (props) {
+      super(props);
+      this.state = {
+        fields: this.props.getInitialFields(),
       };
     }
 

--- a/packages/kununu-form-wrapper/package.json
+++ b/packages/kununu-form-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kununu/kununu-form-wrapper",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "kununu form wrapper HOC",
     "main": "dist",
     "author": "kununu",


### PR DESCRIPTION
While trying to use the form wrapper in app-reviews on the finish page QA section I wasn't able to do everything I needed:

- I had to add a way to update the initial fields since in our case the questions fields are being loaded async after the page has already rendered since we are already in the SPA. The easiest way I could think would be to check if the state is empty and if it is try to update it with the getInitialFields() whenever it receives new data.

- The profanity highlighting is handled within the textField component, I needed a way to update the field error when the user typed some profanity. In order to do this I added a custom error handler. I think this is nice because it allows us to handle the errors in other ways than just the utils validator if we need to.

- I needed a way to check if the form was empty.. I could of added this logic to app-reviews but I feel like it is a useful method that may be used in the future so I added it.

Lastly, onSubmit was updating the fields before validating the form - this caused my customErrorHandling to be removed since "updateField" always re validates. I don't know why you would need to update the fields again on submit 🤔 So I just removed it.. :D 