### PR TITLE
Fix isFormEmpty logic

### DIFF
--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -79,8 +79,8 @@ const FormWrapper = (WrappedComponent) => {
      * a value
      * @returns {bool}
      */
-    formIsEmpty = () => !Object.keys(this.state.fields)
-      .every(key => this.state.fields[key].value)
+    formIsEmpty = () => Object.keys(this.state.fields)
+      .every(key => !this.state.fields[key].value)
 
     /**
      * Validate a given field and return the updated field object

--- a/packages/kununu-form-wrapper/package.json
+++ b/packages/kununu-form-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kununu/kununu-form-wrapper",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "kununu form wrapper HOC",
     "main": "dist",
     "author": "kununu",


### PR DESCRIPTION
This wasn't working since the every(this.state.fields[key].value) will return ```false``` right away if one field is empty (So if you have 3+ fields it will give a false positive)