### PR TITLE
Add support for different field values types

### DIFF
--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -83,16 +83,35 @@ const FormWrapper = (WrappedComponent) => {
       .every(key => !this.state.fields[key].value)
 
     /**
+     * Handles different form values types
+     */
+    handleFieldTypes = (prevVal, val) => {
+      if (typeof prevVal === 'string') {
+        return val;
+      }
+
+      if (Array.isArray(prevVal)) {
+        if (prevVal.includes(val)) {
+          return prevVal.filter(item => item !== val);
+        }
+
+        prevVal.push(val);
+
+        return prevVal;
+      }
+    }
+
+    /**
      * Validate a given field and return the updated field object
      *
-     * @param {string} value
+     * @param {string, array} value
      * @param {string} key
      * @param {bool} touched
      */
     updateField = (value, key, touched = false) => ({
       [key]: {
         ...this.state.fields[key],
-        value,
+        value: this.handleFieldTypes(this.state.fields[key].value, value),
         touched: this.state.fields[key].touched || touched, // touched is unset when field is loaded from local storage
         error: validateField(value, this.state.fields[key].validations),
       },

--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -86,10 +86,6 @@ const FormWrapper = (WrappedComponent) => {
      * Handles different form values types
      */
     handleFieldTypes = (prevVal, val) => {
-      if (typeof prevVal === 'string') {
-        return val;
-      }
-
       if (Array.isArray(prevVal)) {
         if (prevVal.includes(val)) {
           return prevVal.filter(item => item !== val);
@@ -99,6 +95,8 @@ const FormWrapper = (WrappedComponent) => {
 
         return prevVal;
       }
+
+      return val;
     }
 
     /**

--- a/packages/kununu-form-wrapper/index.spec.jsx
+++ b/packages/kununu-form-wrapper/index.spec.jsx
@@ -255,6 +255,72 @@ describe('possible interactions', () => {
     expect(propsFromWrapperAfter).toEqual(false);
   });
 
+  it('will handle different field value types', () => {
+    const initialFields = () => ({
+      question: {
+        value: '',
+        error: false,
+        touched: false,
+        validations: [],
+      },
+      answers: {
+        value: [],
+        error: false,
+        touched: false,
+        validations: [],
+      },
+    });
+
+    const wrapper = mount(<WrapperComponent getInitialFields={() => initialFields()} />);
+    const formElement = wrapper.find('form');
+    const input = wrapper.find('input');
+
+    input.simulate('change', {
+      target: {
+        value: 'question1',
+        name: 'question',
+      },
+    });
+
+    expect(wrapper.state().fields.question.value).toEqual('question1');
+
+    input.simulate('change', {
+      target: {
+        value: 'question2',
+        name: 'question',
+      },
+    });
+
+    expect(wrapper.state().fields.question.value).toEqual('question2');
+
+    input.simulate('change', {
+      target: {
+        value: 'answer1',
+        name: 'answers',
+      },
+    });
+
+    expect(wrapper.state().fields.answers.value).toEqual(['answer1']);
+
+    input.simulate('change', {
+      target: {
+        value: 'answer2',
+        name: 'answers',
+      },
+    });
+
+    expect(wrapper.state().fields.answers.value).toEqual(['answer1', 'answer2']);
+
+    input.simulate('change', {
+      target: {
+        value: 'answer1',
+        name: 'answers',
+      },
+    });
+
+    expect(wrapper.state().fields.answers.value).toEqual(['answer2']);
+  });
+
   it('will handle custom errors', () => {
     const wrapper = shallow(<WrapperComponent getInitialFields={() => getInitialFieldsForUser()} />);
 
@@ -262,4 +328,3 @@ describe('possible interactions', () => {
     expect(wrapper.state().fields.answer.error).toEqual('custom error');
   });
 });
-

--- a/packages/kununu-form-wrapper/index.spec.jsx
+++ b/packages/kununu-form-wrapper/index.spec.jsx
@@ -272,7 +272,6 @@ describe('possible interactions', () => {
     });
 
     const wrapper = mount(<WrapperComponent getInitialFields={() => initialFields()} />);
-    const formElement = wrapper.find('form');
     const input = wrapper.find('input');
 
     input.simulate('change', {

--- a/packages/kununu-form-wrapper/package.json
+++ b/packages/kununu-form-wrapper/package.json
@@ -1,23 +1,23 @@
 {
     "name": "@kununu/kununu-form-wrapper",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "kununu form wrapper HOC",
     "main": "dist",
     "author": "kununu",
     "license": "ISC",
     "devDependencies": {
-        "@kununu/kununu-utils": "1.0.5",
-        "babel-cli": "6.23.0",
+        "@kununu/kununu-utils": "1.7.2",
+        "babel-cli": "6.26.0",
         "cross-env": "5.2.0",
         "enzyme-to-json": "3.3.4",
-        "react": "16.4.1",
+        "react": "16.6.3",
         "rimraf": "2.6.0"
     },
     "peerDependencies": {
-        "prop-types": "15.6.0",
-        "react": "16.4.1",
-        "react-dom": "16.4.1",
-        "@kununu/kununu-utils": "1.0.5"
+        "prop-types": "15.6.2",
+        "react": "16.6.3",
+        "react-dom": "16.6.3",
+        "@kununu/kununu-utils": "1.7.2"
     },
     "scripts": {
         "prepublish": "yarn dist",


### PR DESCRIPTION
This PR aims to add support to Array field values. It should validate and work like this:
 
- Is original field value a String? Just replace it with new value and return
- Is original field value an Array?
- Does this value already exists? Remove it
- Add new value to Array and return it