### PR TITLE
Add README to kununu-icons

### DIFF
--- a/packages/kununu-icons/README.md
+++ b/packages/kununu-icons/README.md
@@ -1,0 +1,26 @@
+# kununu-icons
+kununu-icons is [kununu's](https://wwww.kununu.com) collection of SVG icons used across different projects of ours. These icons can be easily imported as React components.
+
+## Setup
+### Install with `npm` or `yarn`
+```sh
+npm i @kununu/kununu-icons
+# OR
+yarn add @kununu/kununu-icons
+```
+
+### Usage
+Each icon can be imported separatedly, see the list [here](https://github.com/kununu/client-gear/tree/master/packages/kununu-icons).
+
+```javascript
+import IconPlus from '@kununu/kununu-icons/dist/Plus';
+import IconClose from '@kununu/kununu-icons/dist/Close';
+
+<IconPlus />
+<IconClose />
+```
+
+You can assign them classes too:
+```javascript
+<IconPlus className={styles.iconGreen} />
+```

--- a/packages/kununu-icons/README.md
+++ b/packages/kununu-icons/README.md
@@ -20,7 +20,7 @@ import IconClose from '@kununu/kununu-icons/dist/Close';
 <IconClose />
 ```
 
-You can assign them classes too:
+You can also assign them custom classes:
 ```javascript
 <IconPlus className={styles.iconGreen} />
 ```


### PR DESCRIPTION
I think it may look nice to have a README on [npmjs.com/package/@kununu/kununu-icons](https://www.npmjs.com/package/@kununu/kununu-icons) and our GH repo.

I based it on what is live on [nukleus](https://github.com/kununu/nukleus/blob/master/README.md). 

Feel free to add suggestions and/or corrections 👍 