### PR TITLE
re-enable onsubmit validation of form when using handleSubmit

### DIFF
--- a/packages/kununu-form-wrapper/index.jsx
+++ b/packages/kununu-form-wrapper/index.jsx
@@ -212,14 +212,21 @@ const FormWrapper = (WrappedComponent) => {
      * Validate all form fields
      */
     validateForm (callback) {
-      const isFormValid = this.isFormValid();
+      this.setState({
+        fields: Object.keys(this.state.fields).reduce((acc, key) => ({
+          ...acc,
+          ...this.updateField(this.state.fields[key].value, key, true),
+        }), {}),
+      }, () => {
+        const isFormValid = this.isFormValid();
 
-      if (isFormValid) {
-        // this will be submit function in the child component
-        callback(this.getFormValues());
-      } else {
-        this.touchForm(true);
-      }
+        if (isFormValid) {
+          // this will be submit function in the child component
+          callback(this.getFormValues());
+        } else {
+          this.touchForm(true);
+        }
+      });
     }
 
     handleSubmit = (e, callback) => {

--- a/packages/kununu-form-wrapper/package.json
+++ b/packages/kununu-form-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kununu/kununu-form-wrapper",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "kununu form wrapper HOC",
     "main": "dist",
     "author": "kununu",


### PR DESCRIPTION
- Re-enabled onsubmit setting local state in form, followed by validation.
-> Whenever `handleSubmit` function of `FormWrapper` is used, form is validated on submit.