### PR TITLE
[KUNPROF-9] Replace json-stringify-safe with fast-safe-stringify lib

### DIFF
--- a/packages/kununu-utils/kununu-logger/index.js
+++ b/packages/kununu-utils/kununu-logger/index.js
@@ -1,6 +1,6 @@
 import {createLogger, transports, format} from 'winston';
 
-const stringify = require('json-stringify-safe');
+const stringify = require('fast-safe-stringify');
 
 const {timestamp, printf} = format;
 const getColorizedMessage = message => `\x1b[32m${message}\x1b[0m`;

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.10.2",
+  "version": "1.12.0-beta.6",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {
@@ -13,9 +13,9 @@
     "@babel/cli": "7.2.3",
     "cookie": "0.3.1",
     "cookie-parser": "1.4.4",
+    "fast-safe-stringify": "2.0.6",
     "http-status-codes": "1.3.0",
     "isomorphic-fetch": "2.2.1",
-    "json-stringify-safe": "5.0.1",
     "jwt-decode": "2.2.0",
     "react-scroll": "1.7.11",
     "winston": "3.2.1"

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.12.0-beta.6",
+  "version": "1.10.3",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {


### PR DESCRIPTION
https://jira.xing.hh/browse/KUNPROF-9

fast-safe-stringify present far better results when compared to json-stringify-safe performance: https://github.com/davidmarkclements/fast-safe-stringify#benchmarks

It'll help kununu-logger when formatting large logs.