### PR TITLE
Add simple version to header

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "enzyme-to-json": "3.3.5",
     "eslint": "5.10.0",
     "eslint-import-resolver-alias": "1.1.2",
+    "eslint-import-resolver-node": "0.3.2",
     "eslint-loader": "2.1.2",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.14.0",

--- a/packages/kununu-header/Header.jsx
+++ b/packages/kununu-header/Header.jsx
@@ -11,25 +11,53 @@ export default function Header ({
   assetsPath,
   title,
   logoLink,
+  simple,
 }) {
+  const simpleLogo = () => {
+    const content = (
+      <picture>
+        <source
+          srcSet={`${assetsPath}/logo-desktop.svg`}
+        />
+        <img
+          alt={title}
+          aria-hidden="true"
+          className={styles.simpleLogo}
+          rel="presentation"
+          src={`${assetsPath}/logo-desktop.svg`}
+        />
+      </picture>
+    );
+
+    return logoLink ?
+      React.cloneElement(logoLink, logoLink.props, content) :
+      content;
+  };
+
   return (
     <header
       role="banner"
-      className={`${styles.header} ${fixed && styles.fixed}`}
+      className={`${styles.header} ${fixed && styles.fixed} ${simple && styles.simple}`}
     >
       <div className={container}>
         <div className={styles.flex}>
           <div className={styles.pullLeft}>
-            <Logo
-              link={logoLink}
-              assetsPath={assetsPath}
-              title={title}
-            />
+            {simple ? simpleLogo() : (
+              <Logo
+                link={logoLink}
+                assetsPath={assetsPath}
+                title={title}
+              />
+            )}
+
             <span className={styles.title}>{title}</span>
           </div>
-          <div className={styles.pullRight}>
-            {children}
-          </div>
+          {!simple ? (
+            <div className={styles.pullRight}>
+              {children}
+            </div>
+          ) : null
+          }
         </div>
       </div>
     </header>
@@ -43,6 +71,7 @@ Header.propTypes = {
   fixed: PropTypes.bool,
   logoLink: PropTypes.element.isRequired,
   title: PropTypes.string,
+  simple: PropTypes.bool,
 };
 
 Header.defaultProps = {
@@ -51,4 +80,5 @@ Header.defaultProps = {
   container: 'container-fluid',
   fixed: true,
   title: '',
+  simple: false,
 };

--- a/packages/kununu-header/Header.jsx
+++ b/packages/kununu-header/Header.jsx
@@ -15,23 +15,16 @@ export default function Header ({
 }) {
   const simpleLogo = () => {
     const content = (
-      <picture>
-        <source
-          srcSet={`${assetsPath}/logo-desktop.svg`}
-        />
-        <img
-          alt={title}
-          aria-hidden="true"
-          className={styles.simpleLogo}
-          rel="presentation"
-          src={`${assetsPath}/logo-desktop.svg`}
-        />
-      </picture>
+      <img
+        alt={title}
+        aria-hidden="true"
+        className={styles.simpleLogo}
+        rel="presentation"
+        src={`${assetsPath}/logo-desktop.svg`}
+      />
     );
 
-    return logoLink ?
-      React.cloneElement(logoLink, logoLink.props, content) :
-      content;
+    return React.cloneElement(logoLink, logoLink.props, content);
   };
 
   return (
@@ -41,23 +34,15 @@ export default function Header ({
     >
       <div className={container}>
         <div className={styles.flex}>
-          <div className={styles.pullLeft}>
-            {simple ? simpleLogo() : (
-              <Logo
-                link={logoLink}
-                assetsPath={assetsPath}
-                title={title}
-              />
-            )}
-
-            <span className={styles.title}>{title}</span>
-          </div>
-          {!simple ? (
-            <div className={styles.pullRight}>
-              {children}
-            </div>
-          ) : null
-          }
+          {simple ? simpleLogo() : (
+            <Logo
+              link={logoLink}
+              assetsPath={assetsPath}
+              title={title}
+            />
+          )}
+          <span className={styles.title}>{title}</span>
+          {!simple && children}
         </div>
       </div>
     </header>

--- a/packages/kununu-header/Header.spec.jsx
+++ b/packages/kununu-header/Header.spec.jsx
@@ -55,7 +55,7 @@ test('Renders simple Header without crashing', () => {
     <Header
       title="Volle Transparenz am Arbeitsmarkt"
       logoLink={<a href="/test">test</a>}
-      simple={true}
+      simple
     >
       <HeaderNav>
         <HeaderNavItem>

--- a/packages/kununu-header/Header.spec.jsx
+++ b/packages/kununu-header/Header.spec.jsx
@@ -49,3 +49,50 @@ test('Renders Header without crashing', () => {
 
   expect(component).toMatchSnapshot();
 });
+
+test('Renders simple Header without crashing', () => {
+  const component = render(
+    <Header
+      title="Volle Transparenz am Arbeitsmarkt"
+      logoLink={<a href="/test">test</a>}
+      simple={true}
+    >
+      <HeaderNav>
+        <HeaderNavItem>
+          <a href="/test">
+            <span className="hidden-xs">
+              <i
+                className="fa fa-search hidden-xs"
+                aria-hidden="true"
+              />
+              &nbsp; Suchen
+            </span>
+            <i
+              className="fa fa-search visible-xs"
+              aria-hidden="true"
+            />
+          </a>
+        </HeaderNavItem>
+        <HeaderNavItem>
+          <a
+            className=""
+            href="/"
+          >
+            <span className="hidden-xs">Mein kununu </span>
+            <i className="fa fa-user visible-xs" />
+          </a>
+        </HeaderNavItem>
+        <HeaderNavItem>
+          <a
+            href="/"
+            className="btn btn-dd-sm btn-primary"
+          >
+            Firma bewerten
+          </a>
+        </HeaderNavItem>
+      </HeaderNav>
+    </Header>,
+  );
+
+  expect(component).toMatchSnapshot();
+});

--- a/packages/kununu-header/__snapshots__/Header.spec.jsx.snap
+++ b/packages/kununu-header/__snapshots__/Header.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Renders Header without crashing 1`] = `
 <header
-  class="header fixed"
+  class="header fixed false"
   role="banner"
 >
   <div
@@ -98,6 +98,47 @@ exports[`Renders Header without crashing 1`] = `
             </li>
           </ul>
         </nav>
+      </div>
+    </div>
+  </div>
+</header>
+`;
+
+exports[`Renders simple Header without crashing 1`] = `
+<header
+  class="header fixed simple"
+  role="banner"
+>
+  <div
+    class="container-fluid"
+  >
+    <div
+      class="flex"
+    >
+      <div
+        class="pullLeft"
+      >
+        <a
+          href="/test"
+        >
+          <picture>
+            <source
+              srcset="https://assets.kununu.com/images/footer/logo-desktop.svg"
+            />
+            <img
+              alt="Volle Transparenz am Arbeitsmarkt"
+              aria-hidden="true"
+              class="simpleLogo"
+              rel="presentation"
+              src="https://assets.kununu.com/images/footer/logo-desktop.svg"
+            />
+          </picture>
+        </a>
+        <span
+          class="title"
+        >
+          Volle Transparenz am Arbeitsmarkt
+        </span>
       </div>
     </div>
   </div>

--- a/packages/kununu-header/__snapshots__/Header.spec.jsx.snap
+++ b/packages/kununu-header/__snapshots__/Header.spec.jsx.snap
@@ -11,94 +11,86 @@ exports[`Renders Header without crashing 1`] = `
     <div
       class="flex"
     >
-      <div
-        class="pullLeft"
+      <a
+        href="/test"
       >
-        <a
-          href="/test"
-        >
-          <picture>
-            <source
-              media="(max-width: 829px)"
-              srcset="https://assets.kununu.com/images/footer/logo-mobile.svg"
-            />
-            <source
-              media="(min-width: 830px)"
-              srcset="https://assets.kununu.com/images/footer/logo-desktop.svg"
-            />
-            <img
-              alt="Volle Transparenz am Arbeitsmarkt"
-              aria-hidden="true"
-              class="logo"
-              rel="presentation"
-              src="https://assets.kununu.com/images/footer/logo-desktop.svg"
-            />
-          </picture>
-        </a>
-        <span
-          class="title"
-        >
-          Volle Transparenz am Arbeitsmarkt
-        </span>
-      </div>
-      <div
-        class="pullRight"
+        <picture>
+          <source
+            media="(max-width: 829px)"
+            srcset="https://assets.kununu.com/images/footer/logo-mobile.svg"
+          />
+          <source
+            media="(min-width: 830px)"
+            srcset="https://assets.kununu.com/images/footer/logo-desktop.svg"
+          />
+          <img
+            alt="Volle Transparenz am Arbeitsmarkt"
+            aria-hidden="true"
+            class="logo"
+            rel="presentation"
+            src="https://assets.kununu.com/images/footer/logo-desktop.svg"
+          />
+        </picture>
+      </a>
+      <span
+        class="title"
       >
-        <nav
-          class="headerNav"
-        >
-          <ul>
-            <li
-              class="headerNavItem"
+        Volle Transparenz am Arbeitsmarkt
+      </span>
+      <nav
+        class="headerNav"
+      >
+        <ul>
+          <li
+            class="headerNavItem"
+          >
+            <a
+              href="/test"
             >
-              <a
-                href="/test"
+              <span
+                class="hidden-xs"
               >
-                <span
-                  class="hidden-xs"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-search hidden-xs"
-                  />
-                    Suchen
-                </span>
                 <i
                   aria-hidden="true"
-                  class="fa fa-search visible-xs"
+                  class="fa fa-search hidden-xs"
                 />
-              </a>
-            </li>
-            <li
-              class="headerNavItem"
+                  Suchen
+              </span>
+              <i
+                aria-hidden="true"
+                class="fa fa-search visible-xs"
+              />
+            </a>
+          </li>
+          <li
+            class="headerNavItem"
+          >
+            <a
+              class=""
+              href="/"
             >
-              <a
-                class=""
-                href="/"
+              <span
+                class="hidden-xs"
               >
-                <span
-                  class="hidden-xs"
-                >
-                  Mein kununu 
-                </span>
-                <i
-                  class="fa fa-user visible-xs"
-                />
-              </a>
-            </li>
-            <li
-              class="headerNavItem"
+                Mein kununu 
+              </span>
+              <i
+                class="fa fa-user visible-xs"
+              />
+            </a>
+          </li>
+          <li
+            class="headerNavItem"
+          >
+            <a
+              class="btn btn-dd-sm btn-primary"
+              href="/"
             >
-              <a
-                class="btn btn-dd-sm btn-primary"
-                href="/"
-              >
-                Firma bewerten
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              Firma bewerten
+            </a>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </header>
@@ -115,31 +107,22 @@ exports[`Renders simple Header without crashing 1`] = `
     <div
       class="flex"
     >
-      <div
-        class="pullLeft"
+      <a
+        href="/test"
       >
-        <a
-          href="/test"
-        >
-          <picture>
-            <source
-              srcset="https://assets.kununu.com/images/footer/logo-desktop.svg"
-            />
-            <img
-              alt="Volle Transparenz am Arbeitsmarkt"
-              aria-hidden="true"
-              class="simpleLogo"
-              rel="presentation"
-              src="https://assets.kununu.com/images/footer/logo-desktop.svg"
-            />
-          </picture>
-        </a>
-        <span
-          class="title"
-        >
-          Volle Transparenz am Arbeitsmarkt
-        </span>
-      </div>
+        <img
+          alt="Volle Transparenz am Arbeitsmarkt"
+          aria-hidden="true"
+          class="simpleLogo"
+          rel="presentation"
+          src="https://assets.kununu.com/images/footer/logo-desktop.svg"
+        />
+      </a>
+      <span
+        class="title"
+      >
+        Volle Transparenz am Arbeitsmarkt
+      </span>
     </div>
   </div>
 </header>

--- a/packages/kununu-header/index.scss
+++ b/packages/kununu-header/index.scss
@@ -14,6 +14,26 @@
   }
 }
 
+.header.simple {
+  .pullLeft {    
+    @media (max-width: $screen-xs-max) {
+      display: inline-block;
+      flex: none;
+      margin: 0 auto;
+    }
+  }
+
+  .title {
+    @media (min-width: $screen-sm-min) {
+      display: block;
+    }
+  }
+}
+
+.simpleLogo {
+  width: 138px;
+}
+
 .title {
   color: $gray-light;
   font-size: 12px;
@@ -31,11 +51,20 @@
 .flex {
   display: flex;
   align-items: center;
-  flex-grow: 1;
+}
+
+.flex.simple {
+  flex-grow: unset;
+
+  .pullLeft {
+    float: none;
+    margin: 0 auto;
+  }
 }
 
 .pullLeft {
   float: left;
+  flex: 1;
 
   a {
     height: 60px;

--- a/packages/kununu-header/index.scss
+++ b/packages/kununu-header/index.scss
@@ -18,8 +18,12 @@
     justify-content: center;
   }
 
-  .title {
-    @media (min-width: $screen-sm-min) {
+  @media (min-width: $screen-sm-min) {
+    .flex {
+      justify-content: space-between;
+    }
+
+    .title {
       display: block;
     }
   }
@@ -47,10 +51,6 @@
   height: 60px;
   align-items: center;
   justify-content: space-between;
-}
-
-.flex.simple {
-  flex-grow: unset;
 }
 
 .headerNav {

--- a/packages/kununu-header/index.scss
+++ b/packages/kununu-header/index.scss
@@ -3,7 +3,6 @@
 .header {
   background-color: $teal;
   color: $white;
-  max-height: 60px;
   z-index: 990;
 
   &.fixed {
@@ -15,12 +14,8 @@
 }
 
 .header.simple {
-  .pullLeft {    
-    @media (max-width: $screen-xs-max) {
-      display: inline-block;
-      flex: none;
-      margin: 0 auto;
-    }
+  .flex {
+    justify-content: center;
   }
 
   .title {
@@ -40,43 +35,22 @@
   line-height: 18px;
   padding-left: 15px;
   padding: 15px 0  15px 20px;
+  margin-right: auto;
 
   @media (max-width: $screen-sm-max) {
     display: none;
   }
 }
 
-.pullLeft,
-.pullRight,
 .flex {
   display: flex;
+  height: 60px;
   align-items: center;
+  justify-content: space-between;
 }
 
 .flex.simple {
   flex-grow: unset;
-
-  .pullLeft {
-    float: none;
-    margin: 0 auto;
-  }
-}
-
-.pullLeft {
-  float: left;
-  flex: 1;
-
-  a {
-    height: 60px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-  }
-}
-
-.pullRight {
-  float: right;
-  justify-content: flex-end;
 }
 
 .headerNav {

--- a/packages/kununu-header/package.json
+++ b/packages/kununu-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-header",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "kununu Header",
   "main": "dist",
   "author": "kununu",


### PR DESCRIPTION
- The reviews/culture/salary pages now require a minimal header (No buttons, links.. just full logo) on their main pages, and the regular header on the success pages. The homepage should not change.. sooo I've added a "simple" prop to toggle this new minimal header. It is non breaking as it defaults to false.