### PR TITLE
Fix vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build
 
 # package lock files
 /**/package-lock.json
+
+# vscode history files 
+.history/

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {
@@ -12,7 +12,7 @@
     "supertest": "4.0.2"
   },
   "dependencies": {
-    "@pact-foundation/pact-node": "8.4.0",
+    "@pact-foundation/pact-node": "10.11.1",
     "@testing-library/react": "9.3.0",
     "branch-name": "1.0.0",
     "cookie": "0.4.0",


### PR DESCRIPTION
Versions of decompress prior to 4.2.1 are vulnerable to Arbitrary File Write.
We are using decompress through @pact-foundation/pact-node.