### PR TITLE
kununu-utils useIntersection: use disconnect instead of unobserve

### DIFF
--- a/packages/kununu-utils/hooks/useIntersection/index.js
+++ b/packages/kununu-utils/hooks/useIntersection/index.js
@@ -43,7 +43,7 @@ const useIntersection = (options) => {
     }
 
     return () => {
-      observer.current.unobserve(ref.current);
+      observer.current.disconnect();
     };
   }, []);
   return [setRef, isIntersecting];

--- a/packages/kununu-utils/hooks/useIntersection/useIntersection.spec.jsx
+++ b/packages/kununu-utils/hooks/useIntersection/useIntersection.spec.jsx
@@ -7,10 +7,12 @@ import useIntersection from '.';
 
 const observeSpy = jest.fn();
 const unobserveSpy = jest.fn();
+const disconnectSpy = jest.fn();
 
 global.IntersectionObserver = jest.fn(() => ({
   observe: observeSpy,
   unobserve: unobserveSpy,
+  disconnect: disconnectSpy,
 }));
 
 jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
@@ -51,11 +53,10 @@ describe('useIntersection custom hook', () => {
   });
 
   it('should unmount the hook', () => {
-    const {container, unmount} = render(<HookComponent />);
-    const wrapper = container.querySelector('#wrapper');
+    const {unmount} = render(<HookComponent />);
 
     unmount();
-    expect(unobserveSpy).toHaveBeenCalledWith(wrapper);
+    expect(disconnectSpy).toHaveBeenCalledWith();
   });
 
   it('should trigger isIntersecting', () => {

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.25.0",
+  "version": "1.25.1-beta.0",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.25.1-beta.0",
+  "version": "1.25.1",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {


### PR DESCRIPTION
Unmounting the intersection hook sometimes causes errors (and potential memory leaks), since dom elements might have already been unmounted before. This PR uses disconnect instead of unobserve which stops observing in a more general way. 