### PR TITLE
feat(kununu-utils): Add `useTrapFocus` hook

### DIFF
--- a/packages/kununu-utils/hooks/useTrapFocus/__tests__/useTrapFocus.spec.jsx
+++ b/packages/kununu-utils/hooks/useTrapFocus/__tests__/useTrapFocus.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  render, cleanup, fireEvent,
-} from '@testing-library/react';
+import {render, fireEvent} from '@testing-library/react';
 
 import useTrapFocus from '..';
 
@@ -20,8 +18,6 @@ function TrapFocusComponent () {
 }
 
 describe('useTrapFocus', () => {
-  afterEach(cleanup);
-
   it('should add an event on the document', () => {
     const addEventListenerReference = document.addEventListener;
 

--- a/packages/kununu-utils/hooks/useTrapFocus/__tests__/useTrapFocus.spec.jsx
+++ b/packages/kununu-utils/hooks/useTrapFocus/__tests__/useTrapFocus.spec.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {
+  render, cleanup, fireEvent,
+} from '@testing-library/react';
+
+import useTrapFocus from '..';
+
+function TrapFocusComponent () {
+  const ref = useTrapFocus();
+
+  return (
+    <div ref={ref}>
+      <button type="button">First Button</button>
+      <p>Text</p>
+      <button type="button">Middle Button</button>
+      <p>Text</p>
+      <button type="button">Last Button</button>
+    </div>
+  );
+}
+
+describe('useTrapFocus', () => {
+  afterEach(cleanup);
+
+  it('should add an event on the document', () => {
+    const addEventListenerReference = document.addEventListener;
+
+    document.addEventListener = jest.fn();
+
+    render(<TrapFocusComponent />);
+
+    expect(document.addEventListener).toHaveBeenCalledTimes(1);
+    expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    document.addEventListener = addEventListenerReference;
+  });
+
+  it('should remove the event on component unmount', () => {
+    const removeEventListenerReference = document.removeEventListener;
+
+    document.removeEventListener = jest.fn();
+
+    const {unmount} = render(<TrapFocusComponent />);
+
+    unmount();
+
+    expect(document.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    document.removeEventListener = removeEventListenerReference;
+  });
+
+  it('should return the focus to the first element', () => {
+    const {getByText} = render(<TrapFocusComponent />);
+
+    const firstButton = getByText('First Button');
+    const lastButton = getByText('Last Button');
+
+    lastButton.focus();
+    fireEvent.keyDown(lastButton, {key: 'Tab'});
+
+    expect(document.activeElement).toBe(firstButton);
+  });
+
+  it('should return the focus to the last element', () => {
+    const {getByText} = render(<TrapFocusComponent />);
+
+    const firstButton = getByText('First Button');
+    const lastButton = getByText('Last Button');
+
+    firstButton.focus();
+    fireEvent.keyDown(firstButton, {key: 'Tab', shiftKey: true});
+
+    expect(document.activeElement).toBe(lastButton);
+  });
+});

--- a/packages/kununu-utils/hooks/useTrapFocus/index.js
+++ b/packages/kununu-utils/hooks/useTrapFocus/index.js
@@ -1,0 +1,56 @@
+import {useEffect, useRef} from 'react';
+import {tabbable} from 'tabbable';
+
+const TAB_KEY_CODE = 9;
+const TAB_KEY = 'Tab';
+
+/**
+ * @typedef {Object} Ref
+ * @property {HTMLElement} [current]
+ */
+
+/**
+ * Custom hook to trap focus in an element.
+ *
+ * @returns {Ref}
+ */
+function useTrapFocus () {
+  const ref = useRef();
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const focusableElements = tabbable(ref.current);
+    const firstFocusableElement = focusableElements[0];
+    const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+    const handleKeyDown = (event) => {
+      const {key, keyCode, shiftKey} = event;
+
+      if ((key === TAB_KEY || keyCode === TAB_KEY_CODE) && focusableElements.length > 0) {
+        const currentFocusableElement = document.activeElement;
+
+        if (!shiftKey && currentFocusableElement === lastFocusableElement) {
+          event.preventDefault();
+          firstFocusableElement.focus();
+        } else if (shiftKey && currentFocusableElement === firstFocusableElement) {
+          event.preventDefault();
+          lastFocusableElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  return ref;
+}
+
+export default useTrapFocus;

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.25.4",
+  "version": "1.26.0-beta.2",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {
@@ -28,6 +28,7 @@
     "nodegit": "0.27.0",
     "prop-types": "15.7.2",
     "react-scroll": "1.7.12",
+    "tabbable": "5.2.0",
     "uuid": "8.3.1",
     "winston": "3.2.1",
     "winston-transport": "4.3.0"

--- a/packages/kununu-utils/package.json
+++ b/packages/kununu-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-utils",
-  "version": "1.26.0-beta.2",
+  "version": "1.26.0",
   "description": "Utility functions used within kununu client applications",
   "main": "dist",
   "devDependencies": {


### PR DESCRIPTION
# Description

- Added hook to control keyboard navigation using tab inside a given element.
- Used `tabbable` package to figure out elements that can be focusable. The decision to use this package was due to its capability to handle edge cases where we can have elements that can be hidden via CSS, or have disabled the focus with `tabindex="-1"` or even have applied the disabled field. Also the package size is not big and it's tree shakable. [size information](https://bundlephobia.com/result?p=tabbable@5.2.0)